### PR TITLE
Added support for the vivoactive 5

### DIFF
--- a/manifest.xml
+++ b/manifest.xml
@@ -15,6 +15,7 @@
         -->
         <iq:products>
             <iq:product id="fr255"/>
+            <iq:product id="vivoactive5"/>
         </iq:products>
         <!--
             Use "Monkey C: Edit Permissions" from the Visual Studio Code command

--- a/source/BitFaceApp.mc
+++ b/source/BitFaceApp.mc
@@ -17,8 +17,8 @@ class BitFaceApp extends Application.AppBase {
     }
 
     // Return the initial view of your application here
-    function getInitialView() as Array<Views or InputDelegates>? {
-        return [ new BitFaceView() ] as Array<Views or InputDelegates>;
+    function getInitialView() as [Views] or [Views, InputDelegates] {
+        return [ new BitFaceView() ];
     }
 
 }


### PR DESCRIPTION
Thank you for this great watch face! With the changes in this PR I, was able to build it for the vivoactive 5 using Garmins [Monkey C Language Support](https://marketplace.visualstudio.com/items?itemName=garmin.monkey-c) VSCode extension.

![vivoactive5](https://github.com/bit101/bitface/assets/58301325/fc1d67cb-db0a-4519-8d9c-c319ed09f4c6)

Maybe you are interested in merging those changes.
Unfortunately, I can't test whether it changes anything for the Forerunner 255, since I only have this device.