### PR TITLE
Added support for the 24h time format

### DIFF
--- a/resources/settings/properties.xml
+++ b/resources/settings/properties.xml
@@ -1,0 +1,3 @@
+<properties>
+    <property id="UseMilitaryFormat" type="boolean">false</property>
+</properties>

--- a/resources/settings/settings.xml
+++ b/resources/settings/settings.xml
@@ -1,0 +1,5 @@
+<settings>
+    <setting propertyKey="@Properties.UseMilitaryFormat" title="@Strings.MilitaryFormatTitle">
+        <settingConfig type="boolean" />
+    </setting>
+</settings>

--- a/resources/strings/strings.xml
+++ b/resources/strings/strings.xml
@@ -1,3 +1,4 @@
 <strings>
     <string id="AppName">BitFace</string>
+    <string id="MilitaryFormatTitle">Military Format for 24 Hour Time</string>
 </strings>

--- a/source/BitFaceView.mc
+++ b/source/BitFaceView.mc
@@ -37,12 +37,20 @@ class BitFaceView extends WatchUi.WatchFace {
     }
 
     function drawTime(dc) {
+      var timeFormat = "$1$:$2$";
       var clockTime = System.getClockTime();
-      var hour = clockTime.hour;
-      if (hour > 12) {
-        hour -= 12;
+      var hours = clockTime.hour;
+      if (!System.getDeviceSettings().is24Hour) {
+        if (hours > 12) {
+          hours -= 12;
+        }
+      } else {
+          if (getApp().getProperty("UseMilitaryFormat")) {
+              timeFormat = "$1$$2$";
+              hours = hours.format("%02d");
+          }
       }
-      var timeString = Lang.format("$1$:$2$", [hour, clockTime.min.format("%02d")]);
+      var timeString = Lang.format(timeFormat, [hours, clockTime.min.format("%02d")]);
 
       dc.setColor(Graphics.COLOR_WHITE, Graphics.COLOR_TRANSPARENT);
 


### PR DESCRIPTION
This PR would add support for the 24h time format that can be enabled in the system settings.
Unfortunately, I was only able to test this on the vivoactive 5.

![image](https://github.com/bit101/bitface/assets/58301325/c2f65eb8-e85d-4afc-af31-58b6742ec305)

